### PR TITLE
chore(cargo): update `homepage` to `repository`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.2.1"
 authors = ["Aleksey Sidorov <sauron1987@gmail.com>"]
 documentation = "https://docs.rs/include-utils"
 edition = "2021"
-homepage = "https://github.com/alekseysidorov/include-utils"
+repository = "https://github.com/alekseysidorov/include-utils"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
@@ -46,7 +46,7 @@ description = "mdBook-like include macro as the powerful replacement for the sta
 authors.workspace = true
 categories = ["development-tools"]
 documentation.workspace = true
-homepage.workspace = true
+repository.workspace = true
 keywords = ["no_std", "documentation", "rustdoc"]
 license.workspace = true
 

--- a/examples/crate/Cargo.toml
+++ b/examples/crate/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true
-homepage.workspace = true
+repository.workspace = true
 license.workspace = true
 resolver = "2"
 

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true
-homepage.workspace = true
+repository.workspace = true
 license.workspace = true
 publish = false
 

--- a/include-utils-macro/Cargo.toml
+++ b/include-utils-macro/Cargo.toml
@@ -6,7 +6,7 @@ description = "Internal proc macro for the `include-utils` crate."
 
 authors.workspace = true
 documentation.workspace = true
-homepage.workspace = true
+repository.workspace = true
 license.workspace = true
 
 [lib]


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂